### PR TITLE
bugfix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -72945,8 +72945,8 @@ async function run() {
                 const hash = (0, utils_1.computeContentHash)(htmlContent);
                 // we use the name of the file (with the extension) as the path to
                 // avoid post duplication when the repository name is changed.
-                const fileName = path.parse(file).name;
-                if (lockfile.data?.content.find((content) => content.path === file && content.hash === hash)) {
+                const fileName = path.parse(file).base;
+                if (lockfile.data?.content.find((content) => content.path === fileName && content.hash === hash)) {
                     (0, utils_1.log)(`Skipping ${file} because it has not changed.`);
                     continue;
                 }
@@ -72969,12 +72969,12 @@ async function run() {
                 const hash = (0, utils_1.computeContentHash)(markdownContent);
                 // we use the name of the file (with the extension) as the path to
                 // avoid post duplication when the repository name is changed.
-                const fileName = path.parse(file).name;
+                const fileName = path.parse(file).base;
                 if (formattedMarkdown.attributes.draft) {
                     (0, utils_1.log)(`Skipping ${file} because it is a draft.`);
                     continue;
                 }
-                if (lockfile.data?.content.find((content) => content.path === file && content.hash === hash)) {
+                if (lockfile.data?.content.find((content) => content.path === fileName && content.hash === hash)) {
                     (0, utils_1.log)(`Skipping ${file} because it has not changed.`);
                     continue;
                 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,9 +50,9 @@ export async function run(): Promise<void> {
         const hash = computeContentHash(htmlContent)
         // we use the name of the file (with the extension) as the path to
         // avoid post duplication when the repository name is changed.
-        const fileName = path.parse(file).name
+        const fileName = path.parse(file).base
 
-        if (lockfile.data?.content.find((content) => content.path === file && content.hash === hash)) {
+        if (lockfile.data?.content.find((content) => content.path === fileName && content.hash === hash)) {
           log(`Skipping ${file} because it has not changed.`)
           continue
         }
@@ -77,14 +77,14 @@ export async function run(): Promise<void> {
         const hash = computeContentHash(markdownContent)
         // we use the name of the file (with the extension) as the path to
         // avoid post duplication when the repository name is changed.
-        const fileName = path.parse(file).name
+        const fileName = path.parse(file).base
 
         if (formattedMarkdown.attributes.draft) {
           log(`Skipping ${file} because it is a draft.`)
           continue
         }
 
-        if (lockfile.data?.content.find((content) => content.path === file && content.hash === hash)) {
+        if (lockfile.data?.content.find((content) => content.path === fileName && content.hash === hash)) {
           log(`Skipping ${file} because it has not changed.`)
           continue
         }


### PR DESCRIPTION
Fix a bug in #9 where **`if`** & **`else if`** blocks used **file path** instead **file name** for comparison.